### PR TITLE
Handle Varnishadm arguments when -n is present

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -40,7 +40,7 @@ RELDIR="varnishgather-${ID}"
 DIR="${TOPDIR}/${RELDIR}"
 LOG="${DIR}/varnishgather.log"
 ORIGPWD=$PWD
-VERSION="1.53"
+VERSION="1.54"
 USERID="$(id -u)"
 
 # Set up environment
@@ -401,7 +401,12 @@ if [ ! -z "$NAME" ]; then
 	STATCMD="-n $NAME"
 fi
 
-VARNISHADMARG="${SECRET} ${HOSTPORT} ${STATCMD}"
+if [ ! -z "$STATCMD" ]; then
+    VARNISHADMARG="${STATCMD}"
+else
+    VARNISHADMARG="${SECRET} ${HOSTPORT}"
+fi
+
 VARNISH=$(varnishd -V 2>&1)
 
 info "Complete varnishadm command line deduced to: ${VARNISHADMARG}"

--- a/varnishgather
+++ b/varnishgather
@@ -401,10 +401,10 @@ if [ ! -z "$NAME" ]; then
 	STATCMD="-n $NAME"
 fi
 
+VARNISHADMARG="${SECRET} ${HOSTPORT}"
+
 if [ ! -z "$STATCMD" ]; then
     VARNISHADMARG="${STATCMD}"
-else
-    VARNISHADMARG="${SECRET} ${HOSTPORT}"
 fi
 
 VARNISH=$(varnishd -V 2>&1)


### PR DESCRIPTION
-n cannot coexist with -S and -T in varnishadm . The goal is to honour -n if present. 
Previously by passing -n and not explicitly adding it to varnishadm it will pickup another instance port on the same machine. 