### PR TITLE
Gather the content of mse3 config file

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -40,7 +40,7 @@ RELDIR="varnishgather-${ID}"
 DIR="${TOPDIR}/${RELDIR}"
 LOG="${DIR}/varnishgather.log"
 ORIGPWD=$PWD
-VERSION="1.57"
+VERSION="1.58"
 USERID="$(id -u)"
 
 # Set up environment
@@ -509,6 +509,15 @@ pack_vcls
 
 mycat /etc/init.d/varnish
 mycat /etc/default/varnish
+
+# MSE3 configuration file
+MSE3_PATH=$(getarg -s | awk -F, '{print $2}')
+case "$VARNISH" in
+*-[23].*|*-6.0.*)
+        mycat ${MSE3_PATH};;
+*)
+esac
+
 mycat /etc/sysconfig/varnish
 mycat /etc/varnish/varnish.params
 mycat /usr/lib/systemd/system/varnish.service


### PR DESCRIPTION
I've considered the default path as in the docs "/etc/varnish/mse.conf", and if it exists get straight away, otherwise get the "freestyle" config path at the varnishd configuration. Tested also with MSE v2, avoiding to cat the store file to the gather.