### PR TITLE
selinux: Better capture AVC denials

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -38,7 +38,7 @@ TOPDIR=$(mktemp -d /tmp/varnishgather.XXXXXXXX)
 ID="$(cat /etc/hostname)-$(date +'%Y%m%d-%H%M%S')"
 RELDIR="varnishgather-$ID"
 ORIGPWD=$PWD
-VERSION=1.81
+VERSION=1.83
 USERID=$(id -u)
 PID_ALL_VARNISHD=$(pidof varnishd 2> /dev/null)
 PID_ALL_VARNISHD_COMMA=$(pidof varnishd 2> /dev/null | sed 's/ /,/g')
@@ -464,8 +464,7 @@ mycat /etc/redhat-release
 run sysctl -a
 run getenforce
 runpipe "semodule -l" "grep varnish"
-runpipe "ausearch -c varnishd --raw" "audit2allow"	# mgt
-runpipe "ausearch -c cache-main --raw" "audit2allow"	# cld
+runpipe "ausearch --context varnish --raw" "audit2allow"
 run umask
 list_packages varnish
 list_packages vmod


### PR DESCRIPTION
The comm name is highly unreliable, it is supposed to be named after
the executable but can be at the thread granularity once we start naming
them, which we do in varnishd.

The varnishd semodule is also not limited to labeling varnishd, it also
has a context for varnishlog for example. So capturing any context that
matches varnish should bring us denials for both types varnishlog_t and
varnishd_t, and for the latter, denials originating from both mgt and
cache processes.