### PR TITLE
accomodate new varnishadm versions

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -171,7 +171,7 @@ vadmin() {
 
 vadmin_getvcls() {
 	if [ ! -z "${VARNISHADMARG}" ]; then
-		varnishadm ${VARNISHADMARG} vcl.list 2>/dev/null | awk '{if ($2 !~ "label") print $4}'
+		varnishadm ${VARNISHADMARG} vcl.list 2>/dev/null | awk -F ' *|/' '$2 !~ "label" {print $5}'
 	fi
 }
 


### PR DESCRIPTION
newer `varnish` versions changed the output of `varnishadm vcl.list`.

Before:

```
available   auto/cold          0 something
```

after

```
available   auto     cold          0 something_else
```

so `varnishgather` is a bit lost. This work around the issue by checking for a `/` in the second column as I figured it'd be easier and more robust than to compare the versions