### PR TITLE
varnishscoreboard: specify -n to the cmd

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -38,7 +38,7 @@ TOPDIR=$(mktemp -d ${TMPDIR:-/tmp}/varnishgather.XXXXXXXX)
 ID="$(cat /etc/hostname)-$(date +'%Y%m%d-%H%M%S')"
 RELDIR="varnishgather-$ID"
 ORIGPWD=$PWD
-VERSION=1.99
+VERSION=1.100
 USERID=$(id -u)
 PID_ALL_VARNISHD=$(pidof varnishd 2> /dev/null)
 PID_ALL_VARNISHD_COMMA=$(pidof varnishd 2> /dev/null | sed 's/ /,/g')
@@ -557,7 +557,7 @@ run varnishstat -1 $STATCMD
 run varnishstat -j $STATCMD
 run ldd "$(command -v varnishd)"
 run varnishadm ${VARNISHADMARG} debug.jemalloc_stats
-run varnishscoreboard
+run varnishscoreboard $STATCMD
 
 NETSTAT="/bin/netstat"
 run "$NETSTAT" -nlpt


### PR DESCRIPTION
Use the instance name when available to varnishscoreboard, otherwise we will fail to get anything out.