### PR TITLE
filebin: Uploading using --upload-file to stream the file from disk

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -351,7 +351,7 @@ upload() {
 			fi
 
 			URL="${FILEBIN}/${BIN}/${TGZ}"
-			CURLSTATUS=$(curl --data-binary "@$TGZ" $URL \
+			CURLSTATUS=$(curl -X POST --upload-file "$TGZ" $URL \
 				--header "Varnishgather: ${VERSION}" \
 				--progress-bar --silent --output /dev/null \
 				--connect-timeout 60 --max-time 1800 \


### PR DESCRIPTION
Using --data-* to upload the file loads it into memory before sending, this is (slightly) more efficient and can upload larger gathers without running out of memory.

Idea: Since --upload-file accepts stdin data, we could in theory upload the tar file straight to filebin without writing it to disk, but maybe someone prefers having the tar file to scp it as well.