### PR TITLE
lspci: add vebose level

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -38,7 +38,7 @@ TOPDIR=$(mktemp -d ${TMPDIR:-/tmp}/varnishgather.XXXXXXXX)
 ID="$(cat /etc/hostname)-$(date +'%Y%m%d-%H%M%S')"
 RELDIR="varnishgather-$ID"
 ORIGPWD=$PWD
-VERSION=1.100
+VERSION=1.101
 USERID=$(id -u)
 PID_ALL_VARNISHD=$(pidof varnishd 2> /dev/null)
 PID_ALL_VARNISHD_COMMA=$(pidof varnishd 2> /dev/null | sed 's/ /,/g')
@@ -799,7 +799,7 @@ if [ -f /etc/rc.local ]; then
 	run cat /etc/rc.local
 fi
 
-run lspci -v -nn -k
+run lspci -vv -nn -k
 
 cd "$ORIGPWD"
 TGZ="varnishgather.${ID}.tar.gz"


### PR DESCRIPTION
This can be useful to figure out if a NIC is downgraded due to not enough PCIe lanes are available to go at full speed.