### PR TITLE
Add support for collecting sysstat metrics

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -670,6 +670,17 @@ run lsblk
 #	run blockdev --getbsz /dev/$d
 #done
 
+if command -v "sar" >/dev/null 2>&1; then
+	run sar -A
+	run sar -A -1
+	run sar -A -2
+fi
+
+if command -v "sadf" >/dev/null 2>&1; then
+	run sadf -g -O showtoc -- -A
+	run sadf -g -O showtoc -1 -- -A
+	run sadf -g -O showtoc -2 -- -A
+fi
 
 for a in /var/log/messages /var/log/syslog; do
 	if [ -r "$a" ]; then


### PR DESCRIPTION
Collect metrics both as text and as svg graphs for today and two days back.

Example sar output:
```
--------------------------------
Item 150: sar -A
--------------------------------
Linux 4.18.0-553.22.1.el8_10.x86_64 (localhost) 	10/09/24 	_x86_64_	(1 CPU)

00:00:06        CPU      %usr     %nice      %sys   %iowait    %steal      %irq     %soft    %guest    %gnice     %idle
00:10:06        all      4.75      1.01     11.93      2.38      1.87      1.28      1.56      0.00      0.00     75.22
00:10:06          0      4.75      1.01     11.93      2.38      1.87      1.28      1.56      0.00      0.00     75.22
00:20:06        all      4.49      0.00      2.16      0.04      0.48      0.88      0.43      0.00      0.00     91.52
00:20:06          0      4.49      0.00      2.16      0.04      0.48      0.88      0.43      0.00      0.00     91.52
...
```

Example sadf generated SVG:
![image](https://github.com/user-attachments/assets/b86038ab-2bde-44b5-ae1e-afc00c01aac3)
