### PR TITLE
detect Varnish instances and try to be helpful

### DIFF
--- a/varnishgather
+++ b/varnishgather
@@ -38,7 +38,7 @@ TOPDIR=$(mktemp -d ${TMPDIR:-/tmp}/varnishgather.XXXXXXXX)
 ID="$(cat /etc/hostname)-$(date +'%Y%m%d-%H%M%S')"
 RELDIR="varnishgather-$ID"
 ORIGPWD=$PWD
-VERSION=1.104
+VERSION=1.105
 USERID=$(id -u)
 PID_ALL_VARNISHD=$(pidof varnishd 2> /dev/null)
 PID_ALL_VARNISHD_COMMA=$(pidof varnishd 2> /dev/null | sed 's/ /,/g')
@@ -161,6 +161,32 @@ get_pid () {
 		PID_ALL_VARNISHD=$(echo "${PID_VARNISHD} ${PID_CACHEMAIN}" | tr '\n' ' ')
 		PID_ALL_VARNISHD_COMMA=$(echo "${PID_VARNISHD} ${PID_CACHEMAIN}" | tr '\n' ' ' | sed 's/ /,/g')
 	fi
+}
+
+list_names() {
+	# avoid using ps which may not exist in certain environments
+	( for i in /proc/[0-9]*/cmdline; do
+		cat "$i" | tr '\0' ' '
+		echo ""
+	done ) | \
+	awk '
+		$1 ~ /varnishd/ {
+			name="";
+			for (i=1;i<NF;i++) {
+				name="";
+				if ($i=="-n") {
+					name=$(i+1); break
+				}
+			}
+			if(name) {
+				names[n++]=name
+			} else {
+				names[n++]="<noname>"
+			}
+		}
+		END {
+			for (i in names) print names[i]
+		}' | sort -u
 }
 
 vadmin() {
@@ -459,21 +485,57 @@ info "Invoked by: $USERID"
 info "Command line: $*"
 info "Working directory: $DIR"
 
+DELAY=0
 if [ "${USERID}" -ne "0" ]; then
 	echo "#######################################################"
 	echo "Running as non-root, the results might not be complete."
 	echo "Please run again as root."
 	echo "#######################################################"
-	sleep 10
+	DELAY=10
 fi
 
-check_tools
 
-if [ ! $(command -v pidof) ] || [ ! $(command -v pgrep) ]; then
-	 get_pid
+CANDIDATE_NAMES=$(list_names)
+EXIT=
+if ! varnishadm $VARNISHADMARG ping 2>&1 > /dev/null; then
+	echo "#######################################################"
+	echo "using: varnishadm $VARNISHADMARG ping,"
+	echo "We couldn't ping varnishd, Is it running and is"
+	echo "$0 running with the right permissions?"
+	if [ -z "$NAME" -a \
+		$(echo $CANDIDATE_NAMES | wc -w) = 1 -a \
+		"$CANDIDATE_NAMES" != "<noname>" ]; then
+		if varnishadm $VARNISHADMARG -n $CANDIDATE_NAMES ping 2>&1 > /dev/null; then
+			echo ""
+			echo "There's only one varnishd running and it's pingable."
+			echo ""
+			echo "Overriding -n argument to $CANDIDATE_NAMES"
+			NAME="-n $CANDIDATE_NAMES"
+			VARNISHADMARG="$NAME $SECRET $HOSTPORT"
+		else
+			EXIT=1
+		fi
+	# NAME is tested twice, but it saves on indentation
+	elif [ -z "$NAME" -a $(echo $CANDIDATE_NAMES | wc -w) -gt 1 ]; then
+		echo ""
+		echo "We've also detected one or more other varnishd that"
+		echo "could possibly be pinged with these -n arguments:"
+		for n in $CANDIDATE_NAMES; do
+			if [ "$n" != "<noname>" ]; then
+				echo "				-n $n"
+			fi
+		done
+	fi
+	echo "#######################################################"
+	DELAY=10
 fi
 
+if [ -n "$EXIT" ]; then
+	exit 1
+fi
 info "Complete varnishadm command line deduced to: $VARNISHADMARG"
+sleep $DELAY
+
 run varnishd -V
 run varnish-agent -V
 run vha-agent -V


### PR DESCRIPTION
One Karnaugh map later and I realized that https://github.com/varnish/varnishgather/pull/116#discussion_r1809252878
could have been expressed more simply:
- as a rule, when we issue at least one warning, we pause for 10s to give time to the user to read said warning
- if we can ping varnish, proceed
- if we can't ping:
  - if `-n` was given: warn then proceed
  - if there's no `-n`:
    - without any candidate, warn then proceed
    - there's only one candidate, and we can ping it: override, warn then proceed
    - there's only one candidate but we can't ping: error out
    - more than one candidate: list and error our

Read on for example outputs.

If `varnishadm ping` is successful with the current NAME argument, no
question asked, go for it:

```
Info: Working directory: /tmp/varnishgather.Z1LTcYva/varnishgather-flamp-20241106-214646
Info: Complete varnishadm command line deduced to:
Task: 1: varnishd -V
...
```

If pinging failed, there are a few cases:

If NAME was given, or if NAME wasn't given but there's no varnishd
detected, issue a warning, pause a bit, then proceed:

```
Info: Working directory: /tmp/varnishgather.BBE414gf/varnishgather-flamp-20241106-221201
#######################################################
using: varnishadm    ping,
We couldn't ping varnishd, Is it running and is
./varnishgather running with the right permissions?
#######################################################
Info: Complete varnishadm command line deduced to:
<PAUSE 10s>
Task: 1: varnishd -V
...
```

if no NAME was given but there's exactly one candidate, and it's
pingable, override NAME, warn about it, pause then proceed:

```
Info: Working directory: /tmp/varnishgather.ZeUDcfg7/varnishgather-flamp-20241106-222151
#######################################################
using: varnishadm    ping,
We couldn't ping varnishd, Is it running and is
./varnishgather running with the right permissions?

There's only one varnishd running and it's pingable.

Overriding -n argument to /tmp/beepboop
#######################################################
<PAUSE 10s>
Info: Complete varnishadm command line deduced to: -n /tmp/beepboop
Task: 1: varnishd -V
...
```

If no NAME is given, and there's only one candidate but it's not
pingable, just error out:

```
Info: Working directory: /tmp/varnishgather.eZSa78VU/varnishgather-flamp-20241106-224856
#######################################################
using: varnishadm    ping,
We couldn't ping varnishd, Is it running and is
./varnishgather running with the right permissions?
#######################################################
<EXIT>
```

Finally, if there are no given NAME, and we have more than one
candidate, we just propose a list of candidates and error out:

```
Info: Working directory: /tmp/varnishgather.dkGgfqHe/varnishgather-flamp-20241106-223210
#######################################################
using: varnishadm    ping,
We couldn't ping varnishd, Is it running and is
./varnishgather running with the right permissions?

We've also detected one or more varnishd that
could possibly be pinged with these -n arguments:
				-n /tmp/beepboop
				-n /tmp/beepboop2
#######################################################
<EXIT>
```

@hermunn and @zackmay, tagging you in as you were part of the original discussion.